### PR TITLE
Implement API key-based authorization

### DIFF
--- a/Middleware/ApiKeyAuthMiddleware.cs
+++ b/Middleware/ApiKeyAuthMiddleware.cs
@@ -1,9 +1,7 @@
-using Microsoft.AspNetCore.Http;
-using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.Logging;
 using mssqlMCP.Services;
-using System;
-using System.Threading.Tasks;
+using System.Text.Json;
+using mssqlMCP.Models;
+using Newtonsoft.Json.Linq;
 
 namespace mssqlMCP.Middleware;
 
@@ -35,6 +33,13 @@ public class ApiKeyAuthMiddleware
             "";
     }
 
+    private static readonly HashSet<string> UserAllowedApiNames = new()
+    {
+        "notifications/initialized", "tools/list",
+        "Initialize", "ExecuteQuery", "GetTableMetadata", "GetDatabaseObjectsMetadata", "GetDatabaseObjectsByType",
+        "GetSqlServerAgentJobs", "GetSqlServerAgentJobDetails", "GetSsisCatalogInfo", "GetAzureDevOpsInfo"
+    };
+
     public async Task InvokeAsync(HttpContext context)
     {
         // Skip auth check if API key is not configured and we have no API key manager
@@ -45,121 +50,231 @@ public class ApiKeyAuthMiddleware
             return;
         }
 
+        string? token = null;
+        string? authError = null;
+        string? authSource = null;
+
         var authHeader = context.Request.Headers["Authorization"].ToString();
         var apiKeyHeader = context.Request.Headers["X-API-Key"].ToString();
 
-        // Check for either Bearer token or X-API-Key
-        if (string.IsNullOrEmpty(authHeader) && string.IsNullOrEmpty(apiKeyHeader))
-        {
-            _logger.LogWarning("No authentication provided - neither Bearer token nor X-API-Key present");
-            context.Response.StatusCode = 401; // Unauthorized
-            await context.Response.WriteAsJsonAsync(new
-            {
-                error = "Authentication required",
-                message = "Please provide either a Bearer token in the Authorization header or an API key in the X-API-Key header"
-            });
-            return;
-        }
+        context.Request.EnableBuffering();
+        var requestBody = await new StreamReader(context.Request.Body, leaveOpen: true).ReadToEndAsync();
+        context.Request.Body.Position = 0; // Reset stream for next middleware
 
-        // Check Bearer token if present
         if (!string.IsNullOrEmpty(authHeader))
         {
             if (!authHeader.StartsWith("Bearer ", StringComparison.OrdinalIgnoreCase))
             {
-                _logger.LogWarning("Invalid Authorization header format");
-                context.Response.StatusCode = 401; // Unauthorized
-                await context.Response.WriteAsJsonAsync(new
-                {
-                    error = "Invalid Authorization format",
-                    message = "Authorization header must use Bearer scheme"
-                });
-                return;
+                authError = "Authorization header must use Bearer scheme";
             }
-
-            var token = authHeader.Substring("Bearer ".Length).Trim();
-
-            // First check the master key
-            if (!string.IsNullOrEmpty(_masterKey) && string.Equals(token, _masterKey))
+            else
             {
-                _logger.LogInformation("Successfully authenticated using master Bearer token");
-                context.Items["IsAdmin"] = true; // Mark as admin/master key
-                await _next(context);
-                return;
-            }
-
-            // Then check the API key repository
-            if (_apiKeyManager != null)
-            {
-                bool isValid = await _apiKeyManager.ValidateApiKeyAsync(token);
-                if (isValid)
-                {
-                    _logger.LogInformation("Successfully authenticated using stored Bearer token");
-
-                    // Get the API key using the token value, not ID
-                    var apiKey = await _apiKeyRepository.GetApiKeyByValueAsync(token);
-                    if (apiKey != null)
-                    {
-                        await _apiKeyManager.LogApiKeyUsageAsync(context, apiKey.Id, apiKey.UserId);
-                        await _next(context);
-                        return;
-                    }
-                    else
-                    {
-                        _logger.LogWarning("API key validated but could not be retrieved for usage logging");
-                        // Still allow the request to proceed
-                        await _next(context);
-                        return;
-                    }
-                }
+                token = authHeader.Substring("Bearer ".Length).Trim();
+                authSource = "Bearer token";
             }
         }
-
-        // Check X-API-Key if present
-        if (!string.IsNullOrEmpty(apiKeyHeader))
+        else if (!string.IsNullOrEmpty(apiKeyHeader))
         {
-            // First check the master key
-            if (!string.IsNullOrEmpty(_masterKey) && string.Equals(apiKeyHeader, _masterKey))
+            token = apiKeyHeader;
+            authSource = "X-API-Key header";
+        }
+        else
+        {
+            // If no headers, try getting token from the body for JSON-RPC calls
+            token = await GetTokenFromBodyAsync(context, requestBody);
+            if (token != null)
             {
-                _logger.LogInformation("Successfully authenticated using master X-API-Key");
-                context.Items["IsAdmin"] = true; // Mark as admin/master key
-                await _next(context);
-                return;
-            }
-
-            // Then check the API key repository
-            if (_apiKeyManager != null)
-            {
-                var isValid = await _apiKeyManager.ValidateApiKeyAsync(apiKeyHeader);
-                if (isValid)
-                {
-                    _logger.LogInformation("Successfully authenticated using stored X-API-Key");
-
-                    // Get the API key using the value, not ID
-                    var apiKey = await _apiKeyRepository.GetApiKeyByValueAsync(apiKeyHeader);
-                    if (apiKey != null)
-                    {
-                        await _apiKeyManager.LogApiKeyUsageAsync(context, apiKey.Id, apiKey.UserId);
-                        await _next(context);
-                        return;
-                    }
-                    else
-                    {
-                        _logger.LogWarning("API key validated but could not be retrieved for usage logging");
-                        // Still allow the request to proceed
-                        await _next(context);
-                        return;
-                    }
-                }
+                authSource = "JSON-RPC body";
             }
         }
 
-        // If we get here, neither authentication method was successful
-        _logger.LogWarning("Invalid authentication credentials provided");
+        if (authError != null)
+        {
+            _logger.LogWarning("Invalid Authorization header format");
+            context.Response.StatusCode = 401; // Unauthorized
+            await context.Response.WriteAsJsonAsync(new { error = "Invalid Authorization format", message = authError });
+            return;
+        }
+
+        if (string.IsNullOrEmpty(token))
+        {
+            _logger.LogWarning("No authentication provided - checked Bearer token, X-API-Key, and JSON-RPC body.");
+            context.Response.StatusCode = 401; // Unauthorized
+            await context.Response.WriteAsJsonAsync(new { error = "Authentication required", message = "Please provide a valid API key in the Authorization header, X-API-Key header, or the request body for JSON-RPC calls." });
+            return;
+        }
+
+        // Validate the token
+        // 1. Check master key
+        if (!string.IsNullOrEmpty(_masterKey) && string.Equals(token, _masterKey))
+        {
+            _logger.LogInformation("Successfully authenticated using master key from {AuthSource}", authSource);
+            context.Items["IsMaster"] = true;
+            await _next(context);
+            return;
+        }
+
+        // 2. Check API key repository
+        if (_apiKeyManager != null)
+        {
+            var apiKey = await _apiKeyRepository.GetApiKeyByValueAsync(token);
+            if (apiKey != null && await _apiKeyManager.ValidateApiKeyAsync(token))
+            {
+                // Check permissions for user keys
+                if (apiKey.KeyType.Equals("user", StringComparison.OrdinalIgnoreCase))
+                {
+                    if (!await IsUserToolRequest(context, requestBody) ||
+                        !await IsConnectionAllowedAsync(context, requestBody, apiKey))
+                    {
+                        _logger.LogWarning("User key '{ApiKeyName}' ({ApiKeyId}) from {AuthSource} denied access to management endpoint", apiKey.Name, apiKey.Id, authSource);
+                        context.Response.StatusCode = 403; // Forbidden
+                        await context.Response.WriteAsJsonAsync(new { error = "Permission Denied", message = "This API key does not have permission to perform management operations." });
+                        return;
+                    }
+                }
+
+                _logger.LogInformation("Successfully authenticated using stored API key from {AuthSource}", authSource);
+                await _apiKeyManager.LogApiKeyUsageAsync(context, apiKey.Id, apiKey.UserId);
+                await _next(context);
+                return;
+            }
+        }
+
+        // If we get here, the token was invalid
+        _logger.LogWarning("Invalid authentication credentials provided from {AuthSource}", authSource);
         context.Response.StatusCode = 403; // Forbidden
-        await context.Response.WriteAsJsonAsync(new
+        await context.Response.WriteAsJsonAsync(new { error = "Invalid authentication", message = "The provided authentication credentials are not valid" });
+    }
+
+    private async Task<bool> IsConnectionAllowedAsync(HttpContext context, string requestBody, ApiKey apiKey)
+    {
+        // If no specific connections are listed, allow access.
+        if (string.IsNullOrWhiteSpace(apiKey.AllowedConnectionNames))
         {
-            error = "Invalid authentication",
-            message = "The provided authentication credentials are not valid"
-        });
+            return true;
+        }
+
+        // Master key bypasses this check
+        if (context.Items.ContainsKey("IsMaster") && (bool)context.Items["IsMaster"]!)
+        {
+            return true;
+        }
+
+        try
+        {
+            var allowedConnections = JsonSerializer.Deserialize<List<string>>(apiKey.AllowedConnectionNames, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+            if (allowedConnections == null || allowedConnections.Count == 0)
+            {
+                return true; // No restrictions
+            }
+
+            if (string.IsNullOrEmpty(requestBody))
+            {
+                // If there's no request body, we can't check for a connection name.
+                // This might be a request that doesn't require one, so we allow it.
+                return true;
+            }
+
+            var json = JObject.Parse(requestBody);
+            var connectionName = json["params"]?["connectionName"]?.ToString() ?? json["params"]?["arguments"]?["connectionName"]?.ToString();
+
+            {
+                if (connectionName != null && allowedConnections.Contains(connectionName, StringComparer.OrdinalIgnoreCase))
+                {
+                    _logger.LogInformation("Connection '{ConnectionName}' is allowed for API key '{ApiKeyName}'", connectionName, apiKey.Name);
+                    return true;
+                }
+
+                _logger.LogWarning("Forbidden: API key '{ApiKeyName}' is not authorized for connection '{ConnectionName}'", apiKey.Name, connectionName);
+                context.Response.StatusCode = 403; // Forbidden
+                await context.Response.WriteAsJsonAsync(new { error = "Forbidden", message = $"Access to connection '{connectionName}' is not allowed with the provided API key." });
+                return false;
+            }
+
+            // If the request doesn't contain a ConnectionName parameter, we'll allow it to proceed.
+            // The authorization is only for connection-specific tools.
+            return true;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "An unexpected error occurred during connection authorization");
+            context.Response.StatusCode = 500;
+            await context.Response.WriteAsJsonAsync(new { error = "Internal Server Error", message = "An error occurred while processing your request." });
+            return false;
+        }
+    }
+
+    private async Task<string?> GetTokenFromBodyAsync(HttpContext context, string requestBody)
+    {
+        if (!context.Request.Path.Equals("/mcp", StringComparison.OrdinalIgnoreCase) ||
+            !context.Request.Method.Equals("POST", StringComparison.OrdinalIgnoreCase))
+        {
+            return null;
+        }
+
+        try
+        {
+            using var jsonDoc = JsonDocument.Parse(requestBody);
+            if (jsonDoc.RootElement.TryGetProperty("params", out var paramsProp) &&
+                paramsProp.TryGetProperty("_meta", out var metaProp) &&
+                metaProp.TryGetProperty("apiKey", out var apiKeyProp) &&
+                apiKeyProp.ValueKind == JsonValueKind.String)
+            {
+                return apiKeyProp.GetString();
+            }
+        }
+        catch (JsonException ex)
+        {
+            _logger.LogWarning(ex, "Failed to parse request body for API key from JSON-RPC.");
+        }
+
+        return null;
+    }
+
+    private async Task<bool> IsUserToolRequest(HttpContext context, string requestBody)
+    {
+        // Only apply this logic to the MCP endpoint
+        if (!context.Request.Path.Equals("/mcp", StringComparison.OrdinalIgnoreCase) || context.Request.Method != "POST")
+        {
+            return false;
+        }
+
+        try
+        {
+            using var jsonDoc = JsonDocument.Parse(requestBody);
+            var root = jsonDoc.RootElement;
+
+            if (root.TryGetProperty("method", out var methodProperty))
+            {
+                var methodName = methodProperty.GetString();
+                if (methodName != null)
+                {
+                    var apiName = methodName;
+                    if (methodName.Equals("tools/call", StringComparison.OrdinalIgnoreCase))
+                    {
+                        if (root.TryGetProperty("params", out var @params) &&
+                            @params.TryGetProperty("name", out var name))
+                        {
+                            apiName = name.GetString();
+                        }
+                    }
+
+                    _logger.LogInformation("Requesting API: {ToolName}", apiName);
+
+                    // Check for user allowed APIs
+                    if (UserAllowedApiNames.Any(prefix => apiName is not null &&
+                            apiName.Equals(prefix, StringComparison.OrdinalIgnoreCase)))
+                    {
+                        return true;
+                    }
+                }
+            }
+        }
+        catch (JsonException ex)
+        {
+            _logger.LogWarning(ex, "Failed to parse request body for MCP method check");
+        }
+
+        return false;
     }
 }

--- a/Models/ApiKeyModels.cs
+++ b/Models/ApiKeyModels.cs
@@ -62,6 +62,13 @@ public class ApiKey
     /// Optional description of the key's purpose
     /// </summary>
     public string Description { get; set; } = string.Empty;
+
+    /// <summary>
+    /// JSON string array of allowed connection names. If null or empty, all connections are allowed.
+    /// This only applies to user type keys.
+    /// </summary>
+    /// <example>["conn1", "conn2"]</example>
+    public string? AllowedConnectionNames { get; set; }
 }
 
 /// <summary>
@@ -91,6 +98,11 @@ public class CreateApiKeyRequest
     {
         get; set;
     }
+
+    /// <summary>
+    /// Optional list of connection names that this key is allowed to access.
+    /// </summary>
+    public List<string>? AllowedConnectionNames { get; set; }
 }
 
 /// <summary>

--- a/Program.cs
+++ b/Program.cs
@@ -17,6 +17,7 @@ var builder = WebApplication.CreateBuilder(args);
 Log.Logger = new LoggerConfiguration()
     .ReadFrom.Configuration(builder.Configuration)
     .Enrich.FromLogContext()
+    .WriteTo.Console()
     .CreateLogger();
 
 builder.Host.UseSerilog();
@@ -179,6 +180,7 @@ app.UseSerilogRequestLogging(options =>
     };
 });
 
+#if DEBUG
 // Add a direct endpoint for testing
 app.MapGet("/api/test", () => "SQL Server MCP Server is running!");
 
@@ -246,6 +248,7 @@ app.MapGet("/api/tables", async (string? schema, string? connectionName, IConfig
             statusCode: 500);
     }
 });
+#endif
 
 app.UseExceptionHandler(appError =>
 {

--- a/Tests/Middleware/ApiKeyAuthMiddlewareTests.cs
+++ b/Tests/Middleware/ApiKeyAuthMiddlewareTests.cs
@@ -1,0 +1,289 @@
+using Moq;
+using mssqlMCP.Middleware;
+using mssqlMCP.Models;
+using mssqlMCP.Services;
+using System.Text;
+using Xunit;
+
+namespace mssqlMCP.Tests.Middleware
+{
+    public class ApiKeyAuthMiddlewareTests
+    {
+        private readonly Mock<RequestDelegate> _next;
+        private readonly Mock<ILogger<ApiKeyAuthMiddleware>> _logger;
+        private readonly Mock<IConfiguration> _configuration;
+        private readonly Mock<IApiKeyManager> _apiKeyManager;
+        private readonly Mock<IApiKeyRepository> _apiKeyRepository;
+
+        public ApiKeyAuthMiddlewareTests()
+        {
+            _next = new Mock<RequestDelegate>();
+            _logger = new Mock<ILogger<ApiKeyAuthMiddleware>>();
+            _configuration = new Mock<IConfiguration>();
+            _apiKeyManager = new Mock<IApiKeyManager>();
+            _apiKeyRepository = new Mock<IApiKeyRepository>();
+        }
+
+        private ApiKeyAuthMiddleware CreateMiddleware()
+        {
+            return new ApiKeyAuthMiddleware(
+                _next.Object,
+                _logger.Object,
+                _configuration.Object,
+                _apiKeyManager.Object,
+                _apiKeyRepository.Object
+            );
+        }
+
+        private HttpContext CreateHttpContext(string apiKey, string? mcpMethod = null, string @params = "{}")
+        {
+            var context = new DefaultHttpContext();
+            context.Request.Headers["X-API-Key"] = apiKey;
+            if (mcpMethod != null)
+            {
+                context.Request.Path = "/mcp";
+                context.Request.Method = "POST";
+                var requestBody = $"{{\"method\": \"{mcpMethod}\", \"params\": {@params}}}";
+                context.Request.Body = new MemoryStream(Encoding.UTF8.GetBytes(requestBody));
+                context.Request.ContentType = "application/json";
+            }
+
+            return context;
+        }
+
+        [Theory]
+        [InlineData("GetTableMetadata", "{}")]
+        [InlineData("tools/call",
+            "{\"name\":\"GetTableMetadata\",\"arguments\":{},\"_meta\":{\"progressToken\":\"1b4863a3-316a-4796-9a04-77282098a038\"}}")]
+        public async Task UserKey_AccessingAllowedEndpoint_ShouldSucceed(string method, string @params)
+        {
+            // Arrange
+            var userApiKey = new ApiKey { Id = "user1", Name = "Test User Key", Key = "user-key", KeyType = "user" };
+            _apiKeyRepository.Setup(r => r.GetApiKeyByValueAsync("user-key")).ReturnsAsync(userApiKey);
+            _apiKeyManager.Setup(m => m.ValidateApiKeyAsync("user-key")).ReturnsAsync(true);
+
+            var middleware = CreateMiddleware();
+            var context = CreateHttpContext("user-key", method, @params);
+
+            // Act
+            await middleware.InvokeAsync(context);
+
+            // Assert
+            _next.Verify(next => next(context), Times.Once);
+            Assert.NotEqual(403, context.Response.StatusCode);
+        }
+
+        [Theory]
+        [InlineData("CreateApiKey", "{}")]
+        [InlineData("tools/call",
+            "{\"name\":\"CreateApiKey\",\"arguments\":{},\"_meta\":{\"progressToken\":\"1b4863a3-316a-4796-9a04-77282098a038\"}}")]
+        public async Task UserKey_AccessingManagementEndpoint_ShouldBeForbidden(string method, string @params)
+        {
+            // Arrange
+            var userApiKey = new ApiKey { Id = "user1", Name = "Test User Key", Key = "user-key", KeyType = "user" };
+            _apiKeyRepository.Setup(r => r.GetApiKeyByValueAsync("user-key")).ReturnsAsync(userApiKey);
+            _apiKeyManager.Setup(m => m.ValidateApiKeyAsync("user-key")).ReturnsAsync(true);
+
+            var middleware = CreateMiddleware();
+            var context = CreateHttpContext("user-key", method, @params);
+
+            // Act
+            await middleware.InvokeAsync(context);
+
+            // Assert
+            Assert.Equal(403, context.Response.StatusCode);
+            _next.Verify(next => next(context), Times.Never);
+        }
+
+        [Theory]
+        [InlineData("CreateApiKey", "{}")]
+        [InlineData("tools/call",
+            "{\"name\":\"CreateApiKey\",\"arguments\":{},\"_meta\":{\"progressToken\":\"1b4863a3-316a-4796-9a04-77282098a038\"}}")]
+        public async Task AdminKey_AccessingManagementEndpoint_ShouldSucceed(string method, string @params)
+        {
+            // Arrange
+            var adminApiKey = new ApiKey
+                { Id = "admin1", Name = "Test Admin Key", Key = "admin-key", KeyType = "admin" };
+            _apiKeyRepository.Setup(r => r.GetApiKeyByValueAsync("admin-key")).ReturnsAsync(adminApiKey);
+            _apiKeyManager.Setup(m => m.ValidateApiKeyAsync("admin-key")).ReturnsAsync(true);
+
+            var middleware = CreateMiddleware();
+            var context = CreateHttpContext("admin-key", method, @params);
+
+            // Act
+            await middleware.InvokeAsync(context);
+
+            // Assert
+            _next.Verify(next => next(context), Times.Once);
+            Assert.NotEqual(403, context.Response.StatusCode);
+        }
+
+        [Theory]
+        [InlineData("CreateApiKey", "{}")]
+        [InlineData("tools/call",
+            "{\"name\":\"CreateApiKey\",\"arguments\":{},\"_meta\":{\"progressToken\":\"1b4863a3-316a-4796-9a04-77282098a038\"}}")]
+        public async Task MasterKey_AccessingAnyEndpoint_ShouldSucceed(string method, string @params)
+        {
+            // Arrange
+            var masterKey = GetMasterKey();
+            _configuration.Setup(c => c["ApiSecurity:ApiKey"]).Returns(masterKey);
+            var middleware = new ApiKeyAuthMiddleware(_next.Object, _logger.Object, _configuration.Object,
+                _apiKeyManager.Object, _apiKeyRepository.Object);
+            var context = CreateHttpContext(masterKey, method, @params);
+
+            // Act
+            await middleware.InvokeAsync(context);
+
+            // Assert
+            _next.Verify(next => next(context), Times.Once);
+            Assert.True(context.Items.ContainsKey("IsMaster"));
+        }
+
+        private string GetMasterKey() => Environment.GetEnvironmentVariable("MSSQL_MCP_API_KEY") ?? "master-key";
+
+        [Fact]
+        public async Task NoKey_AccessingAnyEndpoint_ShouldBeUnauthorized()
+        {
+            // Arrange
+            var middleware = CreateMiddleware();
+            var context = new DefaultHttpContext(); // No API key
+
+            // Act
+            await middleware.InvokeAsync(context);
+
+            // Assert
+            Assert.Equal(401, context.Response.StatusCode);
+            _next.Verify(next => next(context), Times.Never);
+        }
+
+        [Theory]
+        [InlineData("GetTableMetadata", "{\"connectionName\":\"conn1\"}")]
+        [InlineData("tools/call",
+            "{\"name\":\"GetTableMetadata\",\"arguments\":{\"connectionName\":\"conn1\"},\"_meta\":{\"progressToken\":\"1b4863a3-316a-4796-9a04-77282098a038\"}}")]
+        public async Task UserKey_WithAllowedConnection_ShouldSucceed(string method, string @params)
+        {
+            // Arrange
+            var userApiKey = new ApiKey
+            {
+                Id = "user1", Name = "Test User Key", Key = "user-key", KeyType = "user",
+                AllowedConnectionNames = "[\"conn1\",\"conn2\"]"
+            };
+            _apiKeyRepository.Setup(r => r.GetApiKeyByValueAsync("user-key")).ReturnsAsync(userApiKey);
+            _apiKeyManager.Setup(m => m.ValidateApiKeyAsync("user-key")).ReturnsAsync(true);
+
+            var middleware = CreateMiddleware();
+            var context = CreateHttpContext("user-key", method, @params);
+
+            // Act
+            await middleware.InvokeAsync(context);
+
+            // Assert
+            _next.Verify(next => next(context), Times.Once);
+            Assert.NotEqual(403, context.Response.StatusCode);
+        }
+
+        [Theory]
+        [InlineData("GetTableMetadata", "{\"connectionName\":\"conn3\"}")]
+        [InlineData("tools/call",
+            "{\"name\":\"GetTableMetadata\",\"arguments\":{\"connectionName\":\"conn3\"},\"_meta\":{\"progressToken\":\"1b4863a3-316a-4796-9a04-77282098a038\"}}")]
+        public async Task UserKey_WithDisallowedConnection_ShouldBeForbidden(string method, string @params)
+        {
+            // Arrange
+            var userApiKey = new ApiKey
+            {
+                Id = "user1", Name = "Test User Key", Key = "user-key", KeyType = "user",
+                AllowedConnectionNames = "[\"conn1\",\"conn2\"]"
+            };
+            _apiKeyRepository.Setup(r => r.GetApiKeyByValueAsync("user-key")).ReturnsAsync(userApiKey);
+            _apiKeyManager.Setup(m => m.ValidateApiKeyAsync("user-key")).ReturnsAsync(true);
+
+            var middleware = CreateMiddleware();
+            var context = CreateHttpContext("user-key", method, @params);
+            context.Response.Body = new MemoryStream();
+
+            // Act
+            await middleware.InvokeAsync(context);
+
+            // Assert
+            Assert.Equal(403, context.Response.StatusCode);
+            _next.Verify(next => next(context), Times.Never);
+        }
+
+        [Theory]
+        [InlineData("GetTableMetadata", "{\"connectionName\":\"conn1\"}")]
+        [InlineData("tools/call",
+            "{\"name\":\"GetTableMetadata\",\"arguments\":{\"connectionName\":\"conn1\"},\"_meta\":{\"progressToken\":\"1b4863a3-316a-4796-9a04-77282098a038\"}}")]
+        public async Task UserKey_WithConnectionRestriction_AndNoConnectionInRequest_ShouldSucceed(string method,
+            string @params)
+        {
+            // Arrange
+            var userApiKey = new ApiKey
+            {
+                Id = "user1", Name = "Test User Key", Key = "user-key", KeyType = "user",
+                AllowedConnectionNames = "[\"conn1\",\"conn2\"]"
+            };
+            _apiKeyRepository.Setup(r => r.GetApiKeyByValueAsync("user-key")).ReturnsAsync(userApiKey);
+            _apiKeyManager.Setup(m => m.ValidateApiKeyAsync("user-key")).ReturnsAsync(true);
+
+            var middleware = CreateMiddleware();
+            var context = CreateHttpContext("user-key", method, @params);
+
+            // Act
+            await middleware.InvokeAsync(context);
+
+            // Assert
+            _next.Verify(next => next(context), Times.Once);
+            Assert.NotEqual(403, context.Response.StatusCode);
+        }
+
+        [Theory]
+        [InlineData("GetTableMetadata", "{\"connectionName\":\"conn1\"}")]
+        [InlineData("tools/call",
+            "{\"name\":\"GetTableMetadata\",\"arguments\":{\"connectionName\":\"conn1\"},\"_meta\":{\"progressToken\":\"1b4863a3-316a-4796-9a04-77282098a038\"}}")]
+        public async Task UserKey_WithNoConnectionRestriction_ShouldSucceed(string method, string @params)
+        {
+            // Arrange
+            var userApiKey = new ApiKey
+            {
+                Id = "user1", Name = "Test User Key", Key = "user-key", KeyType = "user", AllowedConnectionNames = "[]"
+            };
+            _apiKeyRepository.Setup(r => r.GetApiKeyByValueAsync("user-key")).ReturnsAsync(userApiKey);
+            _apiKeyManager.Setup(m => m.ValidateApiKeyAsync("user-key")).ReturnsAsync(true);
+
+            var middleware = CreateMiddleware();
+            var context = CreateHttpContext("user-key", method, @params);
+
+            // Act
+            await middleware.InvokeAsync(context);
+
+            // Assert
+            _next.Verify(next => next(context), Times.Once);
+            Assert.NotEqual(403, context.Response.StatusCode);
+        }
+
+        [Theory]
+        [InlineData("GetTableMetadata", "{\"connectionName\":\"conn1\"}")]
+        [InlineData("tools/call",
+            "{\"name\":\"GetTableMetadata\",\"arguments\":{\"connectionName\":\"conn1\"},\"_meta\":{\"progressToken\":\"1b4863a3-316a-4796-9a04-77282098a038\"}}")]
+        public async Task UserKey_WithNullAllowedConnectionNames(string method, string @params)
+        {
+            // Arrange
+            var userApiKey = new ApiKey
+            {
+                Id = "user1", Name = "Test User Key", Key = "user-key", KeyType = "user", AllowedConnectionNames = null
+            };
+            _apiKeyRepository.Setup(r => r.GetApiKeyByValueAsync("user-key")).ReturnsAsync(userApiKey);
+            _apiKeyManager.Setup(m => m.ValidateApiKeyAsync("user-key")).ReturnsAsync(true);
+
+            var middleware = CreateMiddleware();
+            var context = CreateHttpContext("user-key", method, @params);
+
+            // Act
+            await middleware.InvokeAsync(context);
+
+            // Assert
+            _next.Verify(next => next(context), Times.Once);
+            Assert.NotEqual(403, context.Response.StatusCode);
+        }
+    }
+}


### PR DESCRIPTION
1. Prohibit API Keys with `KeyType == "user"` from using management APIs.
2. Added `ApiKey.AllowedConnectionNames` to restrict the connections that users can use.